### PR TITLE
Replace iterations with softIterations

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var prerender = require('./lib');
 
 var server = prerender({
     workers: process.env.PRERENDER_NUM_WORKERS,
-    iterations: process.env.PRERENDER_NUM_ITERATIONS
+    softIterations: process.env.PRERENDER_SOFT_ITERATIONS
 });
 
 


### PR DESCRIPTION
No prerender, se você limitar o número de iterations, quando ele chegar nesse número, ele vai reiniciar o serviço mesmo se tiver request mid flight, ai esses requests retornam 504. Agora troquei pra softIterations pra testar, quando você limita softIterations, o prerender espera todos os requests acabarem antes de reiniciar o serviço.
